### PR TITLE
Add SingleLogoutService SP metadata element

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Config parameter details:
  * `passReqToCallback`: if truthy, `req` will be passed as the first argument to the verify callback (default: `false`)
 * Logout
  * `logoutUrl`: base address to call with logout requests (default: `entryPoint`)
+ * `logoutCallbackUrl`: logout redirect callback URL (default: `/saml/callback`)
  * `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
 
 ### Provide the authentication callback

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -779,6 +779,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
       "Unable to generate service provider metadata when callbackUrl option is not set");
   }
 
+  if (!this.options.logoutCallbackUrl) {
+    this.options.logoutCallbackUrl = this.options.callbackUrl;
+  }
+
   var metadata = {
     'EntityDescriptor' : {
       '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
@@ -793,6 +797,10 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
           '@isDefault': 'true',
           '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
           '@Location': this.options.callbackUrl
+        },
+        'SingleLogoutService': {
+          '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+          '@Location': this.options.logoutCallbackUrl
         }
       },
     }

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -39,5 +39,6 @@ nwtlCg==
     </KeyDescriptor>
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://example.serviceprovider.com/saml/callback"/>
   </SPSSODescriptor>
 </EntityDescriptor>


### PR DESCRIPTION
Introduces a `logoutCallbackUrl` option that specifies the SAML 2.0 logout callback redirect URL.
